### PR TITLE
fix/alsa_crash

### DIFF
--- a/ovos_microphone_plugin_alsa/__init__.py
+++ b/ovos_microphone_plugin_alsa/__init__.py
@@ -44,7 +44,10 @@ class AlsaMicrophone(Microphone):
 
     def read_chunk(self) -> Optional[bytes]:
         assert self._is_running, "Not running"
-        return self._queue.get(timeout=self.timeout)
+        try:
+            return self._queue.get(timeout=self.timeout)
+        except: # let the listener handle this, and maybe restart the plugin
+            return None
 
     def stop(self):
         assert self._thread is not None, "Not started"


### PR DESCRIPTION
closes https://github.com/OpenVoiceOS/ovos-microphone-plugin-alsa/issues/7

exception should then be handled by the listener service https://github.com/OpenVoiceOS/ovos-dinkum-listener/blob/dev/ovos_dinkum_listener/voice_loop/voice_loop.py#L207

its up to the listener to try to recover, or crash the whole process and let the OS restart it, plugins are expected to return None